### PR TITLE
Camera: Add feature extensions 

### DIFF
--- a/libsystem/include/system/camera.h
+++ b/libsystem/include/system/camera.h
@@ -200,6 +200,7 @@ enum {
      * IMPLEMENTATION_DEFINED, then HALv3 devices will use gralloc usage flags
      * of SW_READ_OFTEN.
      */
+ #ifndef CAMERA_VENDOR_L_COMPAT
     CAMERA_CMD_SET_VIDEO_FORMAT = 11,
 
     CAMERA_CMD_VENDOR_START = 20,
@@ -219,6 +220,20 @@ enum {
     CAMERA_CMD_METADATA_ON = CAMERA_CMD_VENDOR_START + 6,
     CAMERA_CMD_METADATA_OFF = CAMERA_CMD_VENDOR_START + 7,
     CAMERA_CMD_VENDOR_END = 200,
+#else
+    /**
+     * Values used by older HALs, provided as an option for compatibility
+     */
+    CAMERA_CMD_HISTOGRAM_ON = 11,
+    CAMERA_CMD_HISTOGRAM_OFF = 12,
+    CAMERA_CMD_HISTOGRAM_SEND_DATA = 13,
+    CAMERA_CMD_LONGSHOT_ON = 14,
+    CAMERA_CMD_LONGSHOT_OFF = 15,
+    CAMERA_CMD_STOP_LONGSHOT = 16,
+    CAMERA_CMD_METADATA_ON = 100,
+    CAMERA_CMD_METADATA_OFF = 101,
+    CAMERA_CMD_SET_VIDEO_FORMAT = 102,
+#endif
 };
 
 /** camera fatal errors */

--- a/libsystem/include/system/camera.h
+++ b/libsystem/include/system/camera.h
@@ -88,7 +88,18 @@ enum {
     // Notify on autofocus start and stop. This is useful in continuous
     // autofocus - FOCUS_MODE_CONTINUOUS_VIDEO and FOCUS_MODE_CONTINUOUS_PICTURE.
     CAMERA_MSG_FOCUS_MOVE = 0x0800,       // notifyCallback
+    CAMERA_MSG_VENDOR_START = 0x1000,
+    CAMERA_MSG_STATS_DATA = CAMERA_MSG_VENDOR_START,
+    CAMERA_MSG_META_DATA = 0x2000,
+    CAMERA_MSG_VENDOR_END = 0x8000,    
     CAMERA_MSG_ALL_MSGS = 0xFFFF
+};
+
+/** meta data type in CameraMetaDataCallback */
+enum {
+    CAMERA_META_DATA_ASD = 0x001,    //ASD data
+    CAMERA_META_DATA_FD = 0x002,     //FD/FP data
+    CAMERA_META_DATA_HDR = 0x003,    //Auto HDR data
 };
 
 /** cmdType in sendCommand functions */
@@ -189,7 +200,25 @@ enum {
      * IMPLEMENTATION_DEFINED, then HALv3 devices will use gralloc usage flags
      * of SW_READ_OFTEN.
      */
-    CAMERA_CMD_SET_VIDEO_FORMAT = 11
+    CAMERA_CMD_SET_VIDEO_FORMAT = 11,
+
+    CAMERA_CMD_VENDOR_START = 20,
+    /**
+     * Commands to enable/disable preview histogram
+     *
+     * Based on user's input to enable/disable histogram from the camera
+     * UI, send the appropriate command to the HAL to turn on/off the histogram
+     * stats and start sending the data to the application.
+     */
+    CAMERA_CMD_HISTOGRAM_ON = CAMERA_CMD_VENDOR_START,
+    CAMERA_CMD_HISTOGRAM_OFF = CAMERA_CMD_VENDOR_START + 1,
+    CAMERA_CMD_HISTOGRAM_SEND_DATA  = CAMERA_CMD_VENDOR_START + 2,
+    CAMERA_CMD_LONGSHOT_ON = CAMERA_CMD_VENDOR_START + 3,
+    CAMERA_CMD_LONGSHOT_OFF = CAMERA_CMD_VENDOR_START + 4,
+    CAMERA_CMD_STOP_LONGSHOT = CAMERA_CMD_VENDOR_START + 5,
+    CAMERA_CMD_METADATA_ON = CAMERA_CMD_VENDOR_START + 6,
+    CAMERA_CMD_METADATA_OFF = CAMERA_CMD_VENDOR_START + 7,
+    CAMERA_CMD_VENDOR_END = 200,
 };
 
 /** camera fatal errors */
@@ -284,8 +313,30 @@ typedef struct camera_face {
      * -2000, -2000 if this is not supported.
      */
     int32_t mouth[2];
+    int32_t smile_degree;
+    int32_t smile_score;
+    int32_t blink_detected;
+    int32_t face_recognised;
+    int32_t gaze_angle;
+    int32_t updown_dir;
+    int32_t leftright_dir;
+    int32_t roll_dir;
+    int32_t left_right_gaze;
+    int32_t top_bottom_gaze;
+    int32_t leye_blink;
+    int32_t reye_blink;
 
 } camera_face_t;
+
+/**
+ * The information of a data type received in a camera frame.
+ */
+typedef enum {
+    /** Data buffer */
+    CAMERA_FRAME_DATA_BUF = 0x000,
+    /** File descriptor */
+    CAMERA_FRAME_DATA_FD = 0x100
+} camera_frame_data_type_t;
 
 /**
  * The metadata of the frame data.


### PR DESCRIPTION
 Camera: Add feature extensions

This change includes below commits:

    Camera bringup changes system-core
    Change-Id: I1cf98641eca9096bd27645e07ea802646ea1fb96

    system/core: Fix for HAL compilation issues while integrating HAL 1.0
    Change-Id: Iead9c1ade279b64c5cbdf4d2de1a8b695939c52a

    Camera: Add enum to specify the frame type
    Added enum to specify the frame type of either fd/data buffer
    CRs-fixed: 654901
    Change-Id: I1c0b1a2c6a1425cdb6650cdfc20ca65835a1b81f

Change-Id: I654a40661e6e101da2a06986abeceb20639cccd9

Former-commit-id: 7067096e4448f1924ce410e0a23776b3203a90a1
Change-Id: I49ea64244b0b6448dc6195d8a7de28b35e8c7560

 Camera: Add L-compatible camera feature enums

 * These QC-specific features have been renumbered in M, so add
   a compilation flag to permit using the old versions in case we
   can't rebuild the driver.

Change-Id: I3f5a545fde8b27684b1b8ea490c09bb66e3b4cd9
Signed-off-by: SagarMakhar <sagarmakhar@gmail.com>
Signed-off-by: Joey Huab <joey@evolution-x.org>